### PR TITLE
#3 JWT 사용을 위한 TokenManager 클래스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/constant/GrantType.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/constant/GrantType.java
@@ -1,0 +1,16 @@
+package com.dailymap.dailymap.domain.jwt.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum GrantType {
+
+    BEARER("Bearer");
+
+    GrantType(String type) {
+        this.type = type;
+    }
+
+    private String type;
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/constant/TokenType.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/constant/TokenType.java
@@ -1,0 +1,17 @@
+package com.dailymap.dailymap.domain.jwt.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+
+    ACCESS,
+    REFRESH,
+    ;
+
+    public static boolean isAccessToken(String tokenType) {
+        String accessTokenName = ACCESS.name();
+        return accessTokenName.equals(tokenType);
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/dto/TokenDto.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/dto/TokenDto.java
@@ -1,4 +1,26 @@
 package com.dailymap.dailymap.domain.jwt.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.util.Date;
+
+@Getter @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class TokenDto {
+
+    private String grantType;
+
+    private String accessToken;
+
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    private Date accessTokenExpireTime;
+
+    private String refreshToken;
+
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    private Date refreshTokenExpireTime;
+
 }

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/dto/TokenDto.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/dto/TokenDto.java
@@ -1,0 +1,4 @@
+package com.dailymap.dailymap.domain.jwt.dto;
+
+public class TokenDto {
+}

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
@@ -1,9 +1,22 @@
 package com.dailymap.dailymap.domain.jwt.service;
 
+import com.dailymap.dailymap.domain.jwt.constant.TokenType;
 import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
+import com.dailymap.dailymap.global.error.exception.ErrorCode;
+import com.dailymap.dailymap.global.error.exception.NotValidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Date;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.NOT_VALID_TOKEN;
+
+@Slf4j
 @Component
 public class TokenManager {
 
@@ -21,6 +34,69 @@ public class TokenManager {
         return null;
     }
 
+    private Date createTokenExpireTime(String tokenExpireTime) {
+        return new Date(System.currentTimeMillis() + Long.parseLong(tokenExpireTime));
+    }
 
+    private String createToken(String email, TokenType tokenType, Date expireTime) {
+        return Jwts.builder()
+            .setSubject(tokenType.name())
+            .setAudience(email)
+            .setIssuedAt(new Date())
+            .setExpiration(expireTime)
+            .signWith(SignatureAlgorithm.HS512, tokenSecret)
+            .setHeaderParam("typ","JWT")
+            .compact();
+    }
+
+    public String getMemberEmail(String accessToken) {
+        String email;
+
+        try {
+            Claims claims = getClaims(accessToken);
+            email = claims.getAudience();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new NotValidTokenException(NOT_VALID_TOKEN);
+        }
+        return email;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException e) {
+            log.info("잘못된 JWT");
+        } catch (Exception e) {
+            log.info("JWT 검증 중 에러 발생");
+        }
+
+        return false;
+    }
+
+    public Claims getTokenClaims(String token) {
+        Claims claims;
+        try {
+            claims = getClaims(token);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new NotValidTokenException(NOT_VALID_TOKEN);
+        }
+        return claims;
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser().setSigningKey(tokenSecret)
+            .parseClaimsJws(token).getBody();
+    }
+
+    public boolean isTokenExpired(Date tokenExpireTime) {
+        Date now = new Date();
+        if (now.after(tokenExpireTime)) {
+            return true;
+        }
+        return false;
+    }
 
 }

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
@@ -1,0 +1,26 @@
+package com.dailymap.dailymap.domain.jwt.service;
+
+import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenManager {
+
+    @Value("${token.access-token-expired-time}")
+    private String accessTokenExpiredTime;
+
+    @Value("${token.refresh-token-expired-time}")
+    private String refreshTokenExpiredTime;
+
+    @Value("${token.secret}")
+    private String tokenSecret;
+
+    public TokenDto createTokenDto(String email) {
+
+        return null;
+    }
+
+
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
@@ -35,7 +35,7 @@ public class TokenManager {
         Date refreshTokenExpireTime = createTokenExpireTime(refreshTokenExpiredTime);
 
         String accessToken = createToken(email, TokenType.ACCESS ,accessTokenExpireTime);
-        String refreshToken = createToken(email, TokenType.REFRESH, accessTokenExpireTime);
+        String refreshToken = createToken(email, TokenType.REFRESH, refreshTokenExpireTime);
 
         GrantType grantType = GrantType.BEARER;
 

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/BusinessException.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package com.dailymap.dailymap.global.error.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private int status;
+
+    public BusinessException(int status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getStatus();
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.dailymap.dailymap.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    // 인증
+    NOT_VALID_TOKEN(401, "유효하지 않은 토큰입니다."),
+    ;
+
+    ErrorCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    private int status;
+    private String message;
+}

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/NotValidTokenException.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/NotValidTokenException.java
@@ -1,0 +1,7 @@
+package com.dailymap.dailymap.global.error.exception;
+
+public class NotValidTokenException extends BusinessException{
+    public NotValidTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,5 +30,5 @@ spring:
 
 token:
   secret: dev-playground-drop
-  access-token-expired-time: 15 * 60 * 1000
-  refresh-token-expired-time: 14 *24 * 60 * 60 * 1000
+  access-token-expired-time: 900000 # 15 * 60 * 1000
+  refresh-token-expired-time: 1210500000 # 4 * 24 * 60 *1 60 * 1000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,7 @@ spring:
     level:
       org.hibernate.type: trace # sql binding 값 출력
 
+token:
+  secret: dev-playground-drop
+  access-token-expired-time: 15 * 60 * 1000
+  refresh-token-expired-time: 14 *24 * 60 * 60 * 1000

--- a/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
+++ b/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
@@ -1,2 +1,75 @@
-package com.dailymap.dailymap.domain.jwt;public class TokenManagerTests {
+package com.dailymap.dailymap.domain.jwt;
+
+import com.dailymap.dailymap.DailymapApplicationTests;
+import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+
+import static com.dailymap.dailymap.domain.jwt.constant.GrantType.BEARER;
+
+
+public class TokenManagerTests extends DailymapApplicationTests {
+
+    @Autowired
+    private TokenManager sut;
+
+    @Test
+    @DisplayName("JWT 정보를 담은 TokenDto 정상 생성 검증")
+    public void memberCreateTokenDtoSucceed() {
+        // Arrange
+
+        // Act
+        TokenDto tokenDto = sut.createTokenDto("test@email.com");
+
+        // Assert
+        Assertions.assertEquals(BEARER.getType(),tokenDto.getGrantType());
+    }
+
+    @Test
+    @DisplayName("TokenManager 클래스를 통해 생성한 JWT 이메일 검증")
+    public void tokenManagerCreateJwtEmailValidate() {
+        // Arrange
+        TokenDto tokenDto = sut.createTokenDto("test@email.com");
+        String accessToken = tokenDto.getAccessToken();
+
+        // Act
+        String email = sut.getMemberEmail(accessToken);
+
+        // Assert
+        Assertions.assertEquals("test@email.com", email);
+    }
+
+    @Test
+    @DisplayName("TokenManager 클래스를 통해 생성한 JWT 유효성 검증")
+    public void tokenManagerCreateJwtValidate() {
+        // Arrange
+        TokenDto tokenDto = sut.createTokenDto("test@email.com");
+        String accessToken = tokenDto.getAccessToken();
+
+        // Act
+        boolean validateToken = sut.validateToken(accessToken);
+
+        // Assert
+        Assertions.assertTrue(validateToken);
+    }
+
+    @Test
+    @DisplayName("TokenManager 클래스를 통해 생성한 JWT 유효기간 검증")
+    public void tokenManagerCreateJwtExpiredFalse() {
+        // Arrange
+        TokenDto tokenDto = sut.createTokenDto("test@email.com");
+        Date expireTime = tokenDto.getAccessTokenExpireTime();
+
+        // Act
+        boolean isTokenExpired = sut.isTokenExpired(expireTime);
+
+        // Assert
+        Assertions.assertFalse(isTokenExpired);
+    }
+
 }

--- a/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
+++ b/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.domain.jwt;public class TokenManagerTests {
+}


### PR DESCRIPTION
### 구현 세부사항

- TokenManager에 사용될 enum 클래스 생성
  - GrantType, TokenType
- accessToken, refreshToken 생성 후 TokenDto에 담아서 전달
  - 토큰 유효기간(accessToken : 15분, refreshToken: 14일)
- TokenManager 단위 테스트 코드 작성
  - createTokenDto() : Jwt 생성 후 TokenDto에 정보 담아서 전달
  - getMemberEmail() : 해당 토큰의 Claims 정보의 email 반환
  - validToken() : 토큰이 유효한지 검증
  - isTokenExpired() : 토큰의 유효기간이 지났는지 검증