### PR TITLE
#5 카카오 계정을 이용한 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.4'
+    id 'org.springframework.boot' version '2.6.4'
     id 'io.spring.dependency-management' version '1.0.14.RELEASE'
     id 'java'
 }
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/dailymap/dailymap/api/login/client/KakaoTokenFeignClient.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/client/KakaoTokenFeignClient.java
@@ -1,2 +1,16 @@
-package com.dailymap.dailymap.api.login.client;public interface KakaoTokenFeignClient {
+package com.dailymap.dailymap.api.login.client;
+
+
+import com.dailymap.dailymap.api.login.dto.KakaoTokenRequestDto;
+import com.dailymap.dailymap.api.login.dto.KakaoTokenResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "kakaoTokenFeignClient", url = "https://kauth.kakao.com")
+public interface KakaoTokenFeignClient {
+
+    @PostMapping(value = "/oauth/token", consumes = "application/x-www-form-urlencoded;charset=utf-8")
+    KakaoTokenResponseDto getKakaoToken(@SpringQueryMap KakaoTokenRequestDto request);
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/client/KakaoTokenFeignClient.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/client/KakaoTokenFeignClient.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.login.client;public interface KakaoTokenFeignClient {
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/client/LoginFeignClient.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/client/LoginFeignClient.java
@@ -1,0 +1,14 @@
+package com.dailymap.dailymap.api.login.client;
+
+import com.dailymap.dailymap.api.login.dto.KakaoUserInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoLoginFeignClient",url = "https://kapi.kakao.com")
+public interface LoginFeignClient {
+
+    @PostMapping(value = "/v2/user/me")
+    KakaoUserInfo getKakaoUserInfo(@RequestHeader("Authorization") String authorization);
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
-@Slf4j
 public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;

--- a/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
@@ -22,10 +22,18 @@ public class KakaoLoginController {
     @Value("${kakao.client.secret}")
     private String clientSecret;
 
+    @Value("${kakao.client.redirect-uri}")
+    private String redirectUri;
 
     @GetMapping("/kakao/callback")
     public ResponseEntity<KakaoTokenResponseDto> loginCallback(String code) {
-        KakaoTokenResponseDto kakaoToken = kakaoLoginService.getKakaoTokenDto(code, clientId, clientSecret);
+        KakaoTokenResponseDto kakaoToken = kakaoLoginService.getKakaoTokenDto(
+            code,
+            clientId,
+            clientSecret,
+            redirectUri
+        );
+
         return ResponseEntity.ok(kakaoToken);
     }
 

--- a/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.login.controller;public class KakaoLoginController {
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
@@ -5,7 +5,6 @@ import com.dailymap.dailymap.api.login.dto.LoginRequestDto;
 import com.dailymap.dailymap.api.login.service.KakaoLoginService;
 import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,7 +38,10 @@ public class KakaoLoginController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> login(@RequestHeader("Authorization") String authorization, @RequestBody LoginRequestDto loginRequestDto) {
+    public ResponseEntity<TokenDto> login(
+        @RequestHeader("Authorization") String authorization,
+        @RequestBody LoginRequestDto loginRequestDto
+    ) {
         TokenDto tokenDto = kakaoLoginService.login(authorization, loginRequestDto);
 
         return ResponseEntity.ok(tokenDto);

--- a/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
@@ -1,2 +1,32 @@
-package com.dailymap.dailymap.api.login.controller;public class KakaoLoginController {
+package com.dailymap.dailymap.api.login.controller;
+
+import com.dailymap.dailymap.api.login.dto.KakaoTokenResponseDto;
+import com.dailymap.dailymap.api.login.service.KakaoLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class KakaoLoginController {
+
+    private final KakaoLoginService kakaoLoginService;
+
+    @Value("${kakao.client.id}")
+    private String clientId;
+
+    @Value("${kakao.client.secret}")
+    private String clientSecret;
+
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<KakaoTokenResponseDto> loginCallback(String code) {
+        KakaoTokenResponseDto kakaoToken = kakaoLoginService.getKakaoTokenDto(code, clientId, clientSecret);
+        return ResponseEntity.ok(kakaoToken);
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/controller/KakaoLoginController.java
@@ -1,17 +1,19 @@
 package com.dailymap.dailymap.api.login.controller;
 
 import com.dailymap.dailymap.api.login.dto.KakaoTokenResponseDto;
+import com.dailymap.dailymap.api.login.dto.LoginRequestDto;
 import com.dailymap.dailymap.api.login.service.KakaoLoginService;
+import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Slf4j
 public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;
@@ -35,6 +37,13 @@ public class KakaoLoginController {
         );
 
         return ResponseEntity.ok(kakaoToken);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> login(@RequestHeader("Authorization") String authorization, @RequestBody LoginRequestDto loginRequestDto) {
+        TokenDto tokenDto = kakaoLoginService.login(authorization, loginRequestDto);
+
+        return ResponseEntity.ok(tokenDto);
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
@@ -17,7 +17,12 @@ public class KakaoTokenRequestDto {
 
     private String client_secret;
 
-    public static KakaoTokenRequestDto of(String code, String clientId, String clientSecret, String redirectUri) {
+    public static KakaoTokenRequestDto of(
+        String code,
+        String clientId,
+        String clientSecret,
+        String redirectUri
+    ) {
         return KakaoTokenRequestDto.builder()
             .grant_type("authorization_code")
             .client_id(clientId)

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.login.dto;public class KakaoTokenRequestDto {
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
@@ -1,2 +1,30 @@
-package com.dailymap.dailymap.api.login.dto;public class KakaoTokenRequestDto {
+package com.dailymap.dailymap.api.login.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoTokenRequestDto {
+
+    private String grant_type;
+
+    private String client_id;
+
+    private String redirect_uri;
+
+    private String code;
+
+    private String client_secret;
+
+    public static KakaoTokenRequestDto of(String code, String clientId, String clientSecret) {
+        return KakaoTokenRequestDto.builder()
+            .grant_type("authorization_code")
+            .client_id(clientId)
+            .redirect_uri("http://localhost/api/auth/kakao/callback")
+            .code(code)
+            .client_secret(clientSecret)
+            .build();
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
@@ -2,6 +2,7 @@ package com.dailymap.dailymap.api.login.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
 
 @Getter
 @Builder
@@ -17,11 +18,12 @@ public class KakaoTokenRequestDto {
 
     private String client_secret;
 
-    public static KakaoTokenRequestDto of(String code, String clientId, String clientSecret) {
+    public static KakaoTokenRequestDto of(String code, String clientId,
+                                          String clientSecret, String redirectUri) {
         return KakaoTokenRequestDto.builder()
             .grant_type("authorization_code")
             .client_id(clientId)
-            .redirect_uri("http://localhost/api/auth/kakao/callback")
+            .redirect_uri(redirectUri)
             .code(code)
             .client_secret(clientSecret)
             .build();

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenRequestDto.java
@@ -2,7 +2,6 @@ package com.dailymap.dailymap.api.login.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.beans.factory.annotation.Value;
 
 @Getter
 @Builder
@@ -18,8 +17,7 @@ public class KakaoTokenRequestDto {
 
     private String client_secret;
 
-    public static KakaoTokenRequestDto of(String code, String clientId,
-                                          String clientSecret, String redirectUri) {
+    public static KakaoTokenRequestDto of(String code, String clientId, String clientSecret, String redirectUri) {
         return KakaoTokenRequestDto.builder()
             .grant_type("authorization_code")
             .client_id(clientId)

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.login.dto;public class KakaoTokenResponseDto {
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoTokenResponseDto.java
@@ -1,2 +1,22 @@
-package com.dailymap.dailymap.api.login.dto;public class KakaoTokenResponseDto {
+package com.dailymap.dailymap.api.login.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoTokenResponseDto {
+
+    private String token_type;
+
+    private String access_token;
+
+    private Integer expires_in;
+
+    private String refresh_token;
+
+    private Integer refresh_token_expires_in;
+
+    private String scope;
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoUserInfo.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/KakaoUserInfo.java
@@ -1,0 +1,28 @@
+package com.dailymap.dailymap.api.login.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@JsonIgnoreProperties({"connected_at"})
+public class KakaoUserInfo {
+
+    private String id;
+
+    private Map<String, String> properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter @Setter
+    @JsonIgnoreProperties({"profile_nickname_needs_agreement", "profile_image_needs_agreement", "profile", "has_email",
+        "email_needs_agreement", "is_email_valid", "is_email_verified"})
+    public static class KakaoAccount {
+        private String email;
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/dto/LoginRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/dto/LoginRequestDto.java
@@ -1,0 +1,15 @@
+package com.dailymap.dailymap.api.login.dto;
+
+
+import com.dailymap.dailymap.domain.member.constant.MemberType;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginRequestDto {
+
+    private MemberType memberType;
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.login.service;public class KakaoLoginService {
+}

--- a/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
@@ -41,7 +41,11 @@ public class KakaoLoginService {
     private final MemberService memberService;
 
     public KakaoTokenResponseDto getKakaoTokenDto(
-        String code, String clientId, String clientSecret, String redirectUri) {
+        String code,
+        String clientId,
+        String clientSecret,
+        String redirectUri
+    ) {
         KakaoTokenRequestDto kakaoTokenRequestDto = KakaoTokenRequestDto.of(
             code,
             clientId,

--- a/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
@@ -1,19 +1,47 @@
 package com.dailymap.dailymap.api.login.service;
 
 import com.dailymap.dailymap.api.login.client.KakaoTokenFeignClient;
+import com.dailymap.dailymap.api.login.client.LoginFeignClient;
 import com.dailymap.dailymap.api.login.dto.KakaoTokenRequestDto;
 import com.dailymap.dailymap.api.login.dto.KakaoTokenResponseDto;
+import com.dailymap.dailymap.api.login.dto.KakaoUserInfo;
+import com.dailymap.dailymap.api.login.dto.LoginRequestDto;
+import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.domain.member.constant.MemberType;
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.member.service.MemberService;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import com.dailymap.dailymap.global.util.DateTimeUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import static com.dailymap.dailymap.domain.member.constant.MemberType.KAKAO;
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.INVALID_MEMBER_TYPE;
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMBER_NOT_EXISTS;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
 public class KakaoLoginService {
 
     private final KakaoTokenFeignClient kakaoTokenFeignClient;
 
-    public KakaoTokenResponseDto getKakaoTokenDto(String code, String clientId,
-                                                  String clientSecret, String redirectUri) {
+    private final LoginFeignClient loginFeignClient;
+
+    private final TokenManager tokenManager;
+
+    private final MemberService memberService;
+
+    public KakaoTokenResponseDto getKakaoTokenDto(
+        String code, String clientId, String clientSecret, String redirectUri) {
         KakaoTokenRequestDto kakaoTokenRequestDto = KakaoTokenRequestDto.of(
             code,
             clientId,
@@ -22,6 +50,50 @@ public class KakaoLoginService {
         );
 
         return kakaoTokenFeignClient.getKakaoToken(kakaoTokenRequestDto);
+    }
+
+    @Transactional
+    public TokenDto login(String authorization, LoginRequestDto loginRequestDto) throws BusinessException{
+        MemberType memberType = loginRequestDto.getMemberType();
+        if (!KAKAO.equals(memberType)) {
+            throw new BusinessException(INVALID_MEMBER_TYPE);
+        }
+
+        KakaoUserInfo userInfo = loginFeignClient.getKakaoUserInfo(authorization);
+        String email = userInfo.getKakaoAccount().getEmail();
+        String username = userInfo.getProperties().get("nickname");
+
+        Optional<Member> findMember = memberService.findMemberByEmail(email);
+        if (findMember.isPresent()) {
+            return updateRefreshInfo(findMember.orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS)));
+        }
+
+        return register(email, username, memberType);
+    }
+
+    private TokenDto register(String email, String name, MemberType memberType) {
+        Member member = Member.of(email, name, memberType);
+        TokenDto tokenDto = tokenManager.createTokenDto(email);
+
+        updateMemberRefreshToken(member, tokenDto);
+        memberService.register(member);
+
+        return tokenDto;
+    }
+
+    private TokenDto updateRefreshInfo(Member member) {
+        TokenDto tokenDto = tokenManager.createTokenDto(member.getEmail());
+        updateMemberRefreshToken(member, tokenDto);
+
+        return tokenDto;
+    }
+
+    private void updateMemberRefreshToken(Member member, TokenDto tokenDto) {
+        String refreshToken = tokenDto.getRefreshToken();
+        Date expireTime = tokenDto.getRefreshTokenExpireTime();
+        LocalDateTime refreshTokenExpireTime = DateTimeUtils.convertToLocalDateTime(expireTime);
+
+        member.updateRefreshInfo(refreshToken, refreshTokenExpireTime);
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
@@ -1,2 +1,20 @@
-package com.dailymap.dailymap.api.login.service;public class KakaoLoginService {
+package com.dailymap.dailymap.api.login.service;
+
+import com.dailymap.dailymap.api.login.client.KakaoTokenFeignClient;
+import com.dailymap.dailymap.api.login.dto.KakaoTokenRequestDto;
+import com.dailymap.dailymap.api.login.dto.KakaoTokenResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    private final KakaoTokenFeignClient kakaoTokenFeignClient;
+
+    public KakaoTokenResponseDto getKakaoTokenDto(String code, String clientId, String clientSecret) {
+        KakaoTokenRequestDto kakaoTokenRequestDto = KakaoTokenRequestDto.of(code, clientId, clientSecret);
+        return kakaoTokenFeignClient.getKakaoToken(kakaoTokenRequestDto);
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
+++ b/src/main/java/com/dailymap/dailymap/api/login/service/KakaoLoginService.java
@@ -12,8 +12,15 @@ public class KakaoLoginService {
 
     private final KakaoTokenFeignClient kakaoTokenFeignClient;
 
-    public KakaoTokenResponseDto getKakaoTokenDto(String code, String clientId, String clientSecret) {
-        KakaoTokenRequestDto kakaoTokenRequestDto = KakaoTokenRequestDto.of(code, clientId, clientSecret);
+    public KakaoTokenResponseDto getKakaoTokenDto(String code, String clientId,
+                                                  String clientSecret, String redirectUri) {
+        KakaoTokenRequestDto kakaoTokenRequestDto = KakaoTokenRequestDto.of(
+            code,
+            clientId,
+            clientSecret,
+            redirectUri
+        );
+
         return kakaoTokenFeignClient.getKakaoToken(kakaoTokenRequestDto);
     }
 

--- a/src/main/java/com/dailymap/dailymap/api/logout/controller/LogoutController.java
+++ b/src/main/java/com/dailymap/dailymap/api/logout/controller/LogoutController.java
@@ -3,6 +3,7 @@ package com.dailymap.dailymap.api.logout.controller;
 
 import com.dailymap.dailymap.api.logout.service.LogoutService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,8 +17,8 @@ public class LogoutController {
     private final LogoutService logoutService;
 
     @PostMapping("/logout")
-    public String logout(@RequestHeader("Authorization")String authorization) {
-        return logoutService.logout(authorization);
+    public ResponseEntity<String> logout(@RequestHeader("Authorization")String authorization) {
+        return ResponseEntity.ok(logoutService.logout(authorization));
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/logout/controller/LogoutController.java
+++ b/src/main/java/com/dailymap/dailymap/api/logout/controller/LogoutController.java
@@ -1,0 +1,23 @@
+package com.dailymap.dailymap.api.logout.controller;
+
+
+import com.dailymap.dailymap.api.logout.service.LogoutService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class LogoutController {
+
+    private final LogoutService logoutService;
+
+    @PostMapping("/logout")
+    public String logout(@RequestHeader("Authorization")String authorization) {
+        return logoutService.logout(authorization);
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/logout/service/LogoutService.java
+++ b/src/main/java/com/dailymap/dailymap/api/logout/service/LogoutService.java
@@ -1,0 +1,38 @@
+package com.dailymap.dailymap.api.logout.service;
+
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.member.service.MemberService;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMBER_NOT_EXISTS;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LogoutService {
+
+    private final TokenManager tokenManager;
+
+    private final MemberService memberService;
+
+    @Transactional
+    public String logout(String authorization) {
+        String refreshToken = authorization.split(" ")[1];
+
+        Claims claims = tokenManager.getTokenClaims(refreshToken);
+        String email = claims.getAudience();
+
+        Member findMember = memberService.findMemberByEmail(email)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS));
+
+        findMember.expireRefreshToken();
+
+        return "logout : success";
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/token/controller/AccessTokenReissueController.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/controller/AccessTokenReissueController.java
@@ -18,7 +18,6 @@ public class AccessTokenReissueController {
     @PostMapping("/token/reissue")
     public AccessTokenResponseDto accessTokenReissue(@RequestHeader("Authorization")String authorization) {
         AccessTokenResponseDto responseDto = accessTokenReissueService.getAccessTokenResponseDto(authorization);
-
         return responseDto;
     }
 

--- a/src/main/java/com/dailymap/dailymap/api/token/controller/AccessTokenReissueController.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/controller/AccessTokenReissueController.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.token.controller;public class AccessTokenReissueController {
+}

--- a/src/main/java/com/dailymap/dailymap/api/token/controller/AccessTokenReissueController.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/controller/AccessTokenReissueController.java
@@ -1,2 +1,25 @@
-package com.dailymap.dailymap.api.token.controller;public class AccessTokenReissueController {
+package com.dailymap.dailymap.api.token.controller;
+
+import com.dailymap.dailymap.api.token.dto.AccessTokenResponseDto;
+import com.dailymap.dailymap.api.token.service.AccessTokenReissueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AccessTokenReissueController {
+
+    private final AccessTokenReissueService accessTokenReissueService;
+
+    @PostMapping("/token/reissue")
+    public AccessTokenResponseDto accessTokenReissue(@RequestHeader("Authorization")String authorization) {
+        AccessTokenResponseDto responseDto = accessTokenReissueService.getAccessTokenResponseDto(authorization);
+
+        return responseDto;
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/token/dto/AccessTokenResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/dto/AccessTokenResponseDto.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.token.dto;public class AccessTokenResponseDto {
+}

--- a/src/main/java/com/dailymap/dailymap/api/token/dto/AccessTokenResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/dto/AccessTokenResponseDto.java
@@ -1,2 +1,27 @@
-package com.dailymap.dailymap.api.token.dto;public class AccessTokenResponseDto {
+package com.dailymap.dailymap.api.token.dto;
+
+import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@Builder
+public class AccessTokenResponseDto {
+
+    private String grantType;
+
+    private String accessToken;
+
+    private Date accessTokenExpireTime;
+
+    public static AccessTokenResponseDto of(TokenDto tokenDto) {
+        return AccessTokenResponseDto.builder()
+            .grantType("Bearer")
+            .accessToken(tokenDto.getAccessToken())
+            .accessTokenExpireTime(tokenDto.getAccessTokenExpireTime())
+            .build();
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/token/service/AccessTokenReissueService.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/service/AccessTokenReissueService.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.api.token.service;public class AccessTokenReissueService {
+}

--- a/src/main/java/com/dailymap/dailymap/api/token/service/AccessTokenReissueService.java
+++ b/src/main/java/com/dailymap/dailymap/api/token/service/AccessTokenReissueService.java
@@ -1,2 +1,42 @@
-package com.dailymap.dailymap.api.token.service;public class AccessTokenReissueService {
+package com.dailymap.dailymap.api.token.service;
+
+import com.dailymap.dailymap.api.token.dto.AccessTokenResponseDto;
+import com.dailymap.dailymap.domain.jwt.dto.TokenDto;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.member.service.MemberService;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class AccessTokenReissueService {
+
+    private final MemberService memberService;
+
+    private final TokenManager tokenManager;
+
+    public AccessTokenResponseDto getAccessTokenResponseDto(String authorization) {
+        String refreshToken = authorization.split(" ")[1];
+
+        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+        String email = findMember.getEmail();
+        Date refreshTokenExpireTime = Timestamp.valueOf(findMember.getTokenExpirationTime());
+
+        if (tokenManager.isTokenExpired(refreshTokenExpireTime)) {
+            throw new BusinessException(REFRESH_TOKEN_EXPIRED);
+        }
+
+        TokenDto tokenDto = tokenManager.createTokenDto(email);
+
+        return AccessTokenResponseDto.of(tokenDto);
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/service/TokenManager.java
@@ -89,7 +89,7 @@ public class TokenManager {
         return false;
     }
 
-    private Claims getTokenClaims(String token) {
+    public Claims getTokenClaims(String token) {
         Claims claims;
         try {
             claims = Jwts.parser().setSigningKey(tokenSecret)

--- a/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
@@ -34,8 +34,20 @@ public class Member extends BaseEntity {
     @Column(length = 250)
     private LocalDateTime tokenExpirationTime;
 
+    public static Member of(String email, String name, MemberType memberType) {
+        return Member.builder()
+            .email(email)
+            .username(name)
+            .memberType(memberType)
+            .build();
+    }
+
     public void updateUsername(String username) {
         this.username = username;
     }
 
+    public void updateRefreshInfo(String refreshToken, LocalDateTime refreshTokenExpireTime) {
+        this.refreshToken = refreshToken;
+        this.tokenExpirationTime = refreshTokenExpireTime;
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
@@ -50,4 +50,8 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
         this.tokenExpirationTime = refreshTokenExpireTime;
     }
+
+    public void expireRefreshToken() {
+        this.tokenExpirationTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/repository/MemberRepository.java
@@ -9,5 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUsername(String username);
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByRefreshToken(String refreshToken);
 
 }

--- a/src/main/java/com/dailymap/dailymap/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/repository/MemberRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUsername(String username);
+    Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/java/com/dailymap/dailymap/domain/member/service/MemberService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/service/MemberService.java
@@ -1,0 +1,32 @@
+package com.dailymap.dailymap.domain.member.service;
+
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.member.repository.MemberRepository;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void register(Member member) throws BusinessException{
+        memberRepository.save(member);
+    }
+
+    public boolean isRegistered(String email) {
+        return findMemberByEmail(email).isPresent();
+    }
+
+    public Optional<Member> findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/member/service/MemberService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/service/MemberService.java
@@ -29,4 +29,7 @@ public class MemberService {
         return memberRepository.findByEmail(email);
     }
 
+    public Optional<Member> findMemberByRefreshToken(String refreshToken) {
+        return memberRepository.findByRefreshToken(refreshToken);
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/global/config/client/FeignConfiguration.java
+++ b/src/main/java/com/dailymap/dailymap/global/config/client/FeignConfiguration.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.global.config.client;public class FeignConfiguration {
+}

--- a/src/main/java/com/dailymap/dailymap/global/config/client/FeignConfiguration.java
+++ b/src/main/java/com/dailymap/dailymap/global/config/client/FeignConfiguration.java
@@ -1,2 +1,29 @@
-package com.dailymap.dailymap.global.config.client;public class FeignConfiguration {
+package com.dailymap.dailymap.global.config.client;
+
+import com.dailymap.dailymap.global.error.FeignClientExceptionErrorDecoder;
+import feign.Logger;
+import feign.codec.ErrorDecoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignClientsConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.dailymap.dailymap")
+@Import(FeignClientsConfiguration.class)
+public class FeignConfiguration {
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(value = ErrorDecoder.class)
+    public FeignClientExceptionErrorDecoder commonFeignErrorDecoder() {
+        return new FeignClientExceptionErrorDecoder();
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/global/error/FeignClientExceptionErrorDecoder.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/FeignClientExceptionErrorDecoder.java
@@ -1,2 +1,18 @@
-package com.dailymap.dailymap.global.error;public class FeignClientExceptionErrorDecoder {
+package com.dailymap.dailymap.global.error;
+
+import com.dailymap.dailymap.global.error.exception.FeignClientException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FeignClientExceptionErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public FeignClientException decode(final String methodKey, final Response response) {
+        log.info(response.toString());
+        String message = response.reason();
+        return new FeignClientException(response.status(), message, response.headers());
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/global/error/FeignClientExceptionErrorDecoder.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/FeignClientExceptionErrorDecoder.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.global.error;public class FeignClientExceptionErrorDecoder {
+}

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -8,9 +8,11 @@ public enum ErrorCode {
     // 인증
     NOT_VALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     INVALID_MEMBER_TYPE(401, "잘못된 회원 타입입니다. (memberType: KAKAO"),
+    REFRESH_TOKEN_EXPIRED(401, "해당 리프레시 토큰은 만료됐습니다."),
 
     // 회원
     MEMBER_NOT_EXISTS(400, "해당 회원은 존재하지 않습니다."),
+    MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN(400, "해당 리프레시 토큰을 가진 회원은 존재하지 않습니다."),
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -7,6 +7,10 @@ public enum ErrorCode {
 
     // 인증
     NOT_VALID_TOKEN(401, "유효하지 않은 토큰입니다."),
+    INVALID_MEMBER_TYPE(401, "잘못된 회원 타입입니다. (memberType: KAKAO"),
+
+    // 회원
+    MEMBER_NOT_EXISTS(400, "해당 회원은 존재하지 않습니다."),
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/FeignClientException.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/FeignClientException.java
@@ -1,2 +1,21 @@
-package com.dailymap.dailymap.global.error.exception;public class FeignClientException {
+package com.dailymap.dailymap.global.error.exception;
+
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class FeignClientException extends RuntimeException{
+
+    private final int status;
+    private final String errorMessage;
+    private final Map<String, Collection<String>> headers;
+
+    public FeignClientException(int status, String errorMessage, Map<String, Collection<String>> headers) {
+        super(errorMessage);
+        this.status = status;
+        this.errorMessage = errorMessage;
+        this.headers = headers;
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/FeignClientException.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/FeignClientException.java
@@ -1,0 +1,2 @@
+package com.dailymap.dailymap.global.error.exception;public class FeignClientException {
+}

--- a/src/main/java/com/dailymap/dailymap/global/util/DateTimeUtils.java
+++ b/src/main/java/com/dailymap/dailymap/global/util/DateTimeUtils.java
@@ -1,0 +1,15 @@
+package com.dailymap.dailymap.global.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+public class DateTimeUtils {
+
+    public static LocalDateTime convertToLocalDateTime(Date date) {
+        return date.toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/web/login/KakaoLoginFormController.java
+++ b/src/main/java/com/dailymap/dailymap/web/login/KakaoLoginFormController.java
@@ -1,0 +1,14 @@
+package com.dailymap.dailymap.web.login;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class KakaoLoginFormController {
+
+    @GetMapping("/login")
+    public String login() {
+        return "loginForm";
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 80
   servlet:
     context-path: /
 
@@ -28,3 +28,7 @@ spring:
     level:
       org.hibernate.type: trace # sql binding 값 출력
 
+kakao:
+  client:
+    id: 661685b0f0b7c48454e26b4cd57f2db1
+    secret: 3EbfiGsb9bam4fx3LhLKlDnSuM8PZ7Zx

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,17 +32,6 @@ spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
 
-# client id 및 secret, token secret은 추후 jasypt나 AWS Secret Manager로 보안설정 예정
-kakao:
-  client:
-    id: 661685b0f0b7c48454e26b4cd57f2db1
-    secret: 3EbfiGsb9bam4fx3LhLKlDnSuM8PZ7Zx
-
-token:
-  secret: dev-playground-drop
-  access-token-expired-time: 900000 # 15 * 60 * 1000
-  refresh-token-expired-time: 1209600000 # 14 * 24 * 60 * 60 * 1000
-
 ---
 spring:
   config:
@@ -62,6 +51,18 @@ spring:
 logging:
   level:
     org.hibernate.type: trace
+
+# client id 및 secret, token secret은 추후 jasypt나 AWS Secret Manager로 보안설정 예정
+kakao:
+  client:
+    id: 661685b0f0b7c48454e26b4cd57f2db1
+    secret: 3EbfiGsb9bam4fx3LhLKlDnSuM8PZ7Zx
+    redirect-uri: http://localhost/api/auth/kakao/callback
+
+token:
+  secret: dev-playground-drop
+  access-token-expired-time: 900000 # 15 * 60 * 1000
+  refresh-token-expired-time: 1210500000 # 4 * 24 * 60 *1 60 * 1000
 
 ---
 spring:
@@ -84,6 +85,18 @@ logging:
   level:
     org.hibernate.type: info
 
+# client id 및 secret, token secret은 추후 jasypt나 AWS Secret Manager로 보안설정 예정
+kakao:
+  client:
+    id: 661685b0f0b7c48454e26b4cd57f2db1
+    secret: 3EbfiGsb9bam4fx3LhLKlDnSuM8PZ7Zx
+    redirect-uri: http://3.34.194.171/api/auth/kakao/callback
+
+token:
+  secret: dev-playground-drop
+  access-token-expired-time: 900000 # 15 * 60 * 1000
+  refresh-token-expired-time: 1210500000 # 4 * 24 * 60 *1 60 * 1000
+
 ---
 spring:
   config:
@@ -96,6 +109,12 @@ spring:
     password: 1234
     driver-class-name: org.h2.Driver
 
+# client id 및 secret, token secret은 추후 jasypt나 AWS Secret Manager로 보안설정 예정
+kakao:
+  client:
+    id: 661685b0f0b7c48454e26b4cd57f2db1
+    secret: 3EbfiGsb9bam4fx3LhLKlDnSuM8PZ7Zx
+    redirect-uri: http://localhost/api/auth/kakao/callback
 
 token:
   secret: dev-playground-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,4 @@ kakao:
   client:
     id: 661685b0f0b7c48454e26b4cd57f2db1
     secret: 3EbfiGsb9bam4fx3LhLKlDnSuM8PZ7Zx
+    redirect-uri: http://localhost/api/auth/kakao/callback

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -24,7 +24,7 @@
 </style>
 <body>
 <div class="wrapper">
-  <a href="https://kauth.kakao.com/oauth/authorize?client_id=661685b0f0b7c48454e26b4cd57f2db1&redirect_uri=http://localhost:8080/auth/kakao/callback&response_type=code">
+  <a href="https://kauth.kakao.com/oauth/authorize?client_id=661685b0f0b7c48454e26b4cd57f2db1&redirect_uri=http://localhost/api/auth/kakao/callback&response_type=code">
     <div class="content">
       카카오 로그인
     </div>

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>카카오 로그인 페이지</title>
+</head>
+<style>
+  .wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+  }
+  .content {
+    font-family: system-ui, serif;
+    font-size: 2rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    background: #ffbe0a;
+  }
+  a {
+    text-decoration-line: none
+  }
+</style>
+<body>
+<div class="wrapper">
+  <a href="https://kauth.kakao.com/oauth/authorize?client_id=661685b0f0b7c48454e26b4cd57f2db1&redirect_uri=http://localhost:8080/auth/kakao/callback&response_type=code">
+    <div class="content">
+      카카오 로그인
+    </div>
+  </a>
+</div>
+</body>
+</html>

--- a/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginControllerTests.java
+++ b/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginControllerTests.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class KakaoLoginControllerTests extends DailymapApplicationTests {
 
     @Mock

--- a/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginControllerTests.java
+++ b/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginControllerTests.java
@@ -1,0 +1,48 @@
+package com.dailymap.dailymap.api.login;
+
+import com.dailymap.dailymap.DailymapApplicationTests;
+import com.dailymap.dailymap.api.login.controller.KakaoLoginController;
+import com.dailymap.dailymap.api.login.dto.KakaoTokenResponseDto;
+import com.dailymap.dailymap.api.login.service.KakaoLoginService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class KakaoLoginControllerTests extends DailymapApplicationTests {
+
+    @Mock
+    KakaoLoginService kakaoLoginService;
+
+    @Test
+    @DisplayName("카카오 토큰 생성 성공 검증")
+    public void getKakaoTokenDtoTest() {
+        // Arrange
+        KakaoLoginController sut = new KakaoLoginController(kakaoLoginService);
+        when(kakaoLoginService.getKakaoTokenDto(
+            "code",
+            null,
+            null,
+            null
+            )
+        ).thenReturn(
+            KakaoTokenResponseDto.builder()
+                .access_token("test.access.token")
+                .build()
+        );
+
+        // Act
+        ResponseEntity<KakaoTokenResponseDto> responseBody = sut.loginCallback("code");
+
+        // Assert
+        Assertions.assertEquals(200, responseBody.getStatusCodeValue());
+        Assertions.assertEquals("test.access.token", responseBody.getBody().getAccess_token());
+    }
+
+}

--- a/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginServiceTests.java
+++ b/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginServiceTests.java
@@ -1,0 +1,39 @@
+package com.dailymap.dailymap.api.login;
+
+import com.dailymap.dailymap.api.login.client.KakaoTokenFeignClient;
+import com.dailymap.dailymap.api.login.dto.KakaoTokenRequestDto;
+import com.dailymap.dailymap.api.login.service.KakaoLoginService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+public class KakaoLoginServiceTests {
+
+    @Mock
+    KakaoTokenFeignClient feignClient;
+
+    @Test
+    @DisplayName("FeignClient를 이용한 카카오 API 호출 검증")
+    public void kakaoAPICallVerificationTest() {
+        // Arrange
+        KakaoLoginService sut = new KakaoLoginService(feignClient);
+
+        // Act
+        sut.getKakaoTokenDto(
+            "code",
+            "clientId",
+            "clientSecret",
+            "redirectUri"
+        );
+
+        // Assert
+        verify(feignClient, times(1)).getKakaoToken(any(KakaoTokenRequestDto.class));
+    }
+
+}

--- a/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginServiceTests.java
+++ b/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginServiceTests.java
@@ -1,8 +1,11 @@
 package com.dailymap.dailymap.api.login;
 
 import com.dailymap.dailymap.api.login.client.KakaoTokenFeignClient;
+import com.dailymap.dailymap.api.login.client.LoginFeignClient;
 import com.dailymap.dailymap.api.login.dto.KakaoTokenRequestDto;
 import com.dailymap.dailymap.api.login.service.KakaoLoginService;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.domain.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,13 +19,27 @@ import static org.mockito.Mockito.*;
 public class KakaoLoginServiceTests {
 
     @Mock
-    KakaoTokenFeignClient feignClient;
+    KakaoTokenFeignClient kakaoTokenFeignClient;
+
+    @Mock
+    LoginFeignClient loginFeignClient;
+
+    @Mock
+    TokenManager tokenManager;
+
+    @Mock
+    MemberService memberService;
 
     @Test
     @DisplayName("FeignClient를 이용한 카카오 API 호출 검증")
     public void kakaoAPICallVerificationTest() {
         // Arrange
-        KakaoLoginService sut = new KakaoLoginService(feignClient);
+        KakaoLoginService sut = new KakaoLoginService(
+            kakaoTokenFeignClient,
+            loginFeignClient,
+            tokenManager,
+            memberService
+        );
 
         // Act
         sut.getKakaoTokenDto(
@@ -33,7 +50,8 @@ public class KakaoLoginServiceTests {
         );
 
         // Assert
-        verify(feignClient, times(1)).getKakaoToken(any(KakaoTokenRequestDto.class));
+        verify(kakaoTokenFeignClient, times(1))
+            .getKakaoToken(any(KakaoTokenRequestDto.class));
     }
 
 }

--- a/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginServiceTests.java
+++ b/src/test/java/com/dailymap/dailymap/api/login/KakaoLoginServiceTests.java
@@ -54,4 +54,14 @@ public class KakaoLoginServiceTests {
             .getKakaoToken(any(KakaoTokenRequestDto.class));
     }
 
+    @Test
+    @DisplayName("카카오 유저정보를 이용한 로그인 및 회원가 검증")
+    public void loginUsingKakaoUserInfoTest() { // 추후 작성
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
 }

--- a/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
+++ b/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
@@ -13,7 +13,7 @@ import java.util.Date;
 
 import static com.dailymap.dailymap.domain.jwt.constant.GrantType.BEARER;
 
-//@ActiveProfiles("")
+@ActiveProfiles("test")
 public class TokenManagerTests extends DailymapApplicationTests {
 
     @Autowired

--- a/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
+++ b/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
@@ -7,12 +7,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Date;
 
 import static com.dailymap.dailymap.domain.jwt.constant.GrantType.BEARER;
 
-
+//@ActiveProfiles("")
 public class TokenManagerTests extends DailymapApplicationTests {
 
     @Autowired


### PR DESCRIPTION
### 구현 세부사항

TokenManager 클래스 구현본이 Merge가 되지않아 미완성

- [x] 카카오 로그인 화면을 이용한 로그인 후 카카오 측 토큰 발급
- [x] 카카오 토큰을 이용한 로그인/회원가입 및 JWT 반환
- [x] JWT Refresh Token을 이용한 JWT Access Token 재발급
- [x] 로그아웃 처리를 통한 JWT Refresh Token 만료