### PR TITLE
#11 JPA Auditing 오류 해결

### DIFF
--- a/src/main/java/com/dailymap/dailymap/domain/common/BaseEntity.java
+++ b/src/main/java/com/dailymap/dailymap/domain/common/BaseEntity.java
@@ -3,11 +3,12 @@ package com.dailymap.dailymap.domain.common;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 
-@EntityListeners(EntityListeners.class)
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public abstract class BaseEntity extends BaseTimeEntity{

--- a/src/main/java/com/dailymap/dailymap/domain/common/BaseEntity.java
+++ b/src/main/java/com/dailymap/dailymap/domain/common/BaseEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 
-@EntityListeners(AuditingEntityListener.class)
+@EntityListeners(value = AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public abstract class BaseEntity extends BaseTimeEntity{

--- a/src/main/java/com/dailymap/dailymap/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/dailymap/dailymap/domain/common/BaseTimeEntity.java
@@ -3,12 +3,13 @@ package com.dailymap.dailymap.domain.common;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
-@EntityListeners(EntityListeners.class)
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public abstract class BaseTimeEntity {

--- a/src/main/java/com/dailymap/dailymap/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/dailymap/dailymap/domain/common/BaseTimeEntity.java
@@ -9,7 +9,7 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
-@EntityListeners(AuditingEntityListener.class)
+@EntityListeners(value = AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public abstract class BaseTimeEntity {

--- a/src/main/java/com/dailymap/dailymap/global/config/jpa/AuditorAwareImpl.java
+++ b/src/main/java/com/dailymap/dailymap/global/config/jpa/AuditorAwareImpl.java
@@ -1,25 +1,21 @@
 package com.dailymap.dailymap.global.config.jpa;
 
 import lombok.NonNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.util.StringUtils;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
 public class AuditorAwareImpl implements AuditorAware<String> {
 
-    @Autowired
-    private HttpServletRequest httpServletRequest;
-
     @NonNull
     @Override
     public Optional<String> getCurrentAuditor() {
-        String modifiedBy = httpServletRequest.getRequestURI();
+        // todo: 어떤 값을 넣을지 결정
+        String modifiedBy = "";
 
         if (!StringUtils.hasText(modifiedBy)) {
-            modifiedBy = "Unknown";
+            modifiedBy = "SERVER";
         }
 
         return Optional.of(modifiedBy);

--- a/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
+++ b/src/test/java/com/dailymap/dailymap/domain/jwt/TokenManagerTests.java
@@ -7,12 +7,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Date;
 
 import static com.dailymap.dailymap.domain.jwt.constant.GrantType.BEARER;
 
 
+@ActiveProfiles("test")
 public class TokenManagerTests extends DailymapApplicationTests {
 
     @Autowired


### PR DESCRIPTION
- createdBy, updatedBy, createTime, updateTime 필드의 값이 자동으로 생성되지 않음
- BaseEntity의 @EntityListenners에 잘못된 값이 들어가 있는 것을 확인 후 해결
- IDE의 자동완성에 너무 의존하지말자...!