### PR TITLE
Springdoc 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    /* Springdoc */
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dailymap/dailymap/global/config/doc/SpringdocConfig.java
+++ b/src/main/java/com/dailymap/dailymap/global/config/doc/SpringdocConfig.java
@@ -1,0 +1,23 @@
+package com.dailymap.dailymap.global.config.doc;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringdocConfig {
+
+    @Bean
+    public OpenAPI springShopOpenAPI() {
+        return new OpenAPI()
+            .info(new Info().title("DROP RESTful API Spec")
+                .description("서버에서 제공하는 REST API 스펙을 기술합니다")
+                .version("v0.0.1"))
+            .externalDocs(new ExternalDocumentation()
+                .description("Notion for This Project")
+                .url("https://www.notion.so/byeongsoon/DROP-881b5e0084f54f76985ca12b4211a91c"));
+    }
+
+}


### PR DESCRIPTION
`OpenAPI 3.0` 기반의 API 스펙을 제공하기 위해 `OpenAPI 3.0` 구현 라이브러리인 `Springdoc`을 적용 및 설정합니다.