### PR TITLE
#13 헤더 Authorization 검증을 위한 인터셉터 구현

### DIFF
--- a/src/main/java/com/dailymap/dailymap/domain/jwt/constant/TokenType.java
+++ b/src/main/java/com/dailymap/dailymap/domain/jwt/constant/TokenType.java
@@ -14,4 +14,9 @@ public enum TokenType {
         return accessTokenName.equals(tokenType);
     }
 
+    public static boolean isRefreshToken(String tokenType) {
+        String refreshTokenName = REFRESH.name();
+        return refreshTokenName.equals(tokenType);
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/global/config/WebConfig.java
+++ b/src/main/java/com/dailymap/dailymap/global/config/WebConfig.java
@@ -1,0 +1,42 @@
+package com.dailymap.dailymap.global.config;
+
+import com.dailymap.dailymap.global.interceptor.AccessTokenUseInterceptor;
+import com.dailymap.dailymap.global.interceptor.AuthenticationInterceptor;
+import com.dailymap.dailymap.global.interceptor.RefreshTokenUseInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticationInterceptor requestHeaderInterceptor;
+
+    private final AccessTokenUseInterceptor accessTokenUseInterceptor;
+
+    private final RefreshTokenUseInterceptor refreshTokenUseInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(requestHeaderInterceptor)
+            .order(1)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/health")
+            .excludePathPatterns("/api/auth/kakao/callback")
+            .excludePathPatterns("/api/auth/login");
+        registry.addInterceptor(refreshTokenUseInterceptor)
+            .order(2)
+            .addPathPatterns("/api/auth/**")
+            .excludePathPatterns("/api/auth/kakao/callback")
+            .excludePathPatterns("/api/auth/login");
+        registry.addInterceptor(accessTokenUseInterceptor)
+            .order(3)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/health")
+            .excludePathPatterns("/api/auth/**");
+
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/AuthorizationException.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/AuthorizationException.java
@@ -1,0 +1,7 @@
+package com.dailymap.dailymap.global.error.exception;
+
+public class AuthorizationException extends BusinessException{
+    public AuthorizationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -9,6 +9,11 @@ public enum ErrorCode {
     NOT_VALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     INVALID_MEMBER_TYPE(401, "잘못된 회원 타입입니다. (memberType: KAKAO"),
     REFRESH_TOKEN_EXPIRED(401, "해당 리프레시 토큰은 만료됐습니다."),
+    ACCESS_TOKEN_EXPIRED(401, "해당 액세스 토큰은 만료됐습니다."),
+    NOT_EXISTS_AUTHORIZATION(401, "Authorization Header가 빈 값 입니다."),
+    NOT_VALID_BEARER_GRANT_TYPE(401, "인증 타입이 Bearer 타입이 아닙니다."),
+    NOT_ACCESS_TOKEN_TYPE(401, "토큰 타입이 액세스 토큰이 아닙니다."),
+    NOT_REFRESH_TOKEN_TYPE(401, "토큰 타입이 리프레시 토큰이 아닙니다."),
 
     // 회원
     MEMBER_NOT_EXISTS(400, "해당 회원은 존재하지 않습니다."),

--- a/src/main/java/com/dailymap/dailymap/global/interceptor/AccessTokenUseInterceptor.java
+++ b/src/main/java/com/dailymap/dailymap/global/interceptor/AccessTokenUseInterceptor.java
@@ -1,0 +1,49 @@
+package com.dailymap.dailymap.global.interceptor;
+
+import com.dailymap.dailymap.domain.jwt.constant.TokenType;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.global.error.exception.AuthorizationException;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.ACCESS_TOKEN_EXPIRED;
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.NOT_ACCESS_TOKEN_TYPE;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenUseInterceptor implements HandlerInterceptor {
+
+    private final TokenManager tokenManager;
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) throws BusinessException {
+        String authorization = request.getHeader("Authorization");
+        String accessToken = authorization.split(" ")[1];
+
+        Claims claims = tokenManager.getTokenClaims(accessToken);
+
+        String tokenType = claims.getSubject();
+        if (!TokenType.isAccessToken(tokenType)) {
+            throw new AuthorizationException(NOT_ACCESS_TOKEN_TYPE);
+        }
+
+        Date expireTime = claims.getExpiration();
+        if (tokenManager.isTokenExpired(expireTime)) {
+            throw new AuthorizationException(ACCESS_TOKEN_EXPIRED);
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/dailymap/dailymap/global/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,49 @@
+package com.dailymap.dailymap.global.interceptor;
+
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.global.error.exception.AuthorizationException;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.*;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final TokenManager tokenManager;
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) throws BusinessException {
+        String authorization = request.getHeader("Authorization");
+
+        if (!StringUtils.hasText(authorization)) {
+            throw new AuthorizationException(NOT_EXISTS_AUTHORIZATION);
+        }
+
+        String bearer = authorization.split(" ")[0];
+        if (!"Bearer".equals(bearer)) {
+            throw new AuthorizationException(NOT_VALID_BEARER_GRANT_TYPE);
+        }
+
+        String token = authorization.split(" ")[1];
+        if (!tokenManager.validateToken(token)) {
+            throw new AuthorizationException(NOT_VALID_TOKEN);
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/global/interceptor/RefreshTokenUseInterceptor.java
+++ b/src/main/java/com/dailymap/dailymap/global/interceptor/RefreshTokenUseInterceptor.java
@@ -1,0 +1,48 @@
+package com.dailymap.dailymap.global.interceptor;
+
+import com.dailymap.dailymap.domain.jwt.constant.TokenType;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.global.error.exception.AuthorizationException;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.*;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenUseInterceptor implements HandlerInterceptor {
+
+    private final TokenManager tokenManager;
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) throws BusinessException {
+        String authorization = request.getHeader("Authorization");
+        String refreshToken = authorization.split(" ")[1];
+
+        Claims claims = tokenManager.getTokenClaims(refreshToken);
+
+        String tokenType = claims.getSubject();
+        if (!TokenType.isRefreshToken(tokenType)) {
+            throw new AuthorizationException(NOT_REFRESH_TOKEN_TYPE);
+        }
+
+        Date expireTime = claims.getExpiration();
+        if (tokenManager.isTokenExpired(expireTime)) {
+            throw new AuthorizationException(REFRESH_TOKEN_EXPIRED);
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
## 인터셉터 구현

헤더에 포함된 토큰 정보를 컨트롤러에 전달하기 이전에 검증하기 위한 인터셉터를 구현한다. 아래의 요구사항을 모두 갖추어 개발하였다.

### 요구 사항
- [x] Header의 Authorization이 빈 값일 때
- [x] Header의 Authorization이 Bearer이 아닐 때
- [x] Accesstoken과 RefreshToken을 용도에 맞게 사용하지 않을 때
- [x] 토큰의 유효기간이 지났을 때
- [x] 헬스체크와 로그인 등 검증일 필요 없을 때