### PR TITLE
#23 회원정보 조회 API, #24 회원 탈퇴 API, #27 회원 닉네임 수정 API

### DIFF
--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/controller/MemberInfoController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/controller/MemberInfoController.java
@@ -31,4 +31,9 @@ public class MemberInfoController {
         return ResponseEntity.ok(memberInfoResponseDto);
     }
 
+    @DeleteMapping("/user")
+    public ResponseEntity<String> memberSecession(@RequestHeader("Authorization")String authorization) {
+        return ResponseEntity.ok(memberInfoService.memberSecession(authorization));
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/controller/MemberInfoController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/controller/MemberInfoController.java
@@ -1,0 +1,25 @@
+package com.dailymap.dailymap.api.memberinfo.controller;
+
+import com.dailymap.dailymap.api.memberinfo.dto.MemberInfoResponseDto;
+import com.dailymap.dailymap.api.memberinfo.service.MemberInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class MemberInfoController {
+
+    private final MemberInfoService memberInfoService;
+
+    @GetMapping("/user")
+    public ResponseEntity<MemberInfoResponseDto> findMemberInfo(@RequestHeader("Authorization") String authorization) {
+        MemberInfoResponseDto memberInfoResponseDto = memberInfoService.getMemberInfo(authorization);
+        return ResponseEntity.ok(memberInfoResponseDto);
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/controller/MemberInfoController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/controller/MemberInfoController.java
@@ -1,13 +1,13 @@
 package com.dailymap.dailymap.api.memberinfo.controller;
 
 import com.dailymap.dailymap.api.memberinfo.dto.MemberInfoResponseDto;
+import com.dailymap.dailymap.api.memberinfo.dto.UpdateUsernameRequestDto;
 import com.dailymap.dailymap.api.memberinfo.service.MemberInfoService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -19,6 +19,15 @@ public class MemberInfoController {
     @GetMapping("/user")
     public ResponseEntity<MemberInfoResponseDto> findMemberInfo(@RequestHeader("Authorization") String authorization) {
         MemberInfoResponseDto memberInfoResponseDto = memberInfoService.getMemberInfo(authorization);
+        return ResponseEntity.ok(memberInfoResponseDto);
+    }
+
+    @PatchMapping("/user")
+    public ResponseEntity<MemberInfoResponseDto> updateMemberUsername(
+        @RequestHeader("Authorization")String authorization,
+        @RequestBody UpdateUsernameRequestDto requestDto
+        ) {
+        MemberInfoResponseDto memberInfoResponseDto = memberInfoService.updateUsername(authorization,requestDto);
         return ResponseEntity.ok(memberInfoResponseDto);
     }
 

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/dto/MemberInfoResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/dto/MemberInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.dailymap.dailymap.api.memberinfo.dto;
+
+import com.dailymap.dailymap.domain.member.model.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberInfoResponseDto {
+
+    private Long id;
+
+    private String email;
+
+    private String username;
+
+    public static MemberInfoResponseDto of(Member member) {
+        return MemberInfoResponseDto.builder()
+            .id(member.getId())
+            .email(member.getEmail())
+            .username(member.getUsername())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/dto/MemberInfoResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/dto/MemberInfoResponseDto.java
@@ -1,6 +1,7 @@
 package com.dailymap.dailymap.api.memberinfo.dto;
 
 import com.dailymap.dailymap.domain.member.model.Member;
+
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/dto/UpdateUsernameRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/dto/UpdateUsernameRequestDto.java
@@ -1,0 +1,12 @@
+package com.dailymap.dailymap.api.memberinfo.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateUsernameRequestDto {
+
+    private String username;
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
@@ -1,15 +1,21 @@
 package com.dailymap.dailymap.api.memberinfo.service;
 
 import com.dailymap.dailymap.api.memberinfo.dto.MemberInfoResponseDto;
+import com.dailymap.dailymap.api.memberinfo.dto.UpdateUsernameRequestDto;
 import com.dailymap.dailymap.domain.member.model.Member;
 import com.dailymap.dailymap.domain.member.service.MemberService;
 import com.dailymap.dailymap.global.error.exception.BusinessException;
-import com.dailymap.dailymap.global.error.exception.ErrorCode;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberInfoService {
 
     private final MemberService memberService;
@@ -19,7 +25,20 @@ public class MemberInfoService {
         String refreshToken = authorization.split(" ")[1];
 
         Member findMember = memberService.findMemberByRefreshToken(refreshToken)
-            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+
+        return MemberInfoResponseDto.of(findMember);
+    }
+
+    @Transactional
+    public MemberInfoResponseDto updateUsername(String authorization, UpdateUsernameRequestDto requestDto) {
+        String refreshToken = authorization.split(" ")[1];
+
+        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+
+        String newUsername = requestDto.getUsername();
+        findMember.updateUsername(newUsername);
 
         return MemberInfoResponseDto.of(findMember);
     }

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
@@ -21,7 +21,7 @@ public class MemberInfoService {
     private final MemberService memberService;
 
     public MemberInfoResponseDto getMemberInfo(String authorization) {
-        String refreshToken = authorization.split(" ")[1];
+        String refreshToken = getRefreshToken(authorization);
 
         Member findMember = getMemberByRefreshToken(refreshToken);
 
@@ -30,7 +30,7 @@ public class MemberInfoService {
 
     @Transactional
     public MemberInfoResponseDto updateUsername(String authorization, UpdateUsernameRequestDto requestDto) {
-        String refreshToken = authorization.split(" ")[1];
+        String refreshToken = getRefreshToken(authorization);
 
         Member findMember = getMemberByRefreshToken(refreshToken);
 
@@ -42,7 +42,7 @@ public class MemberInfoService {
 
     @Transactional
     public String memberSecession(String authorization) {
-        String refreshToken = authorization.split(" ")[1];
+        String refreshToken = getRefreshToken(authorization);
 
         Member findMember = getMemberByRefreshToken(refreshToken);
 
@@ -53,6 +53,10 @@ public class MemberInfoService {
     private Member getMemberByRefreshToken(String refreshToken) {
         return memberService.findMemberByRefreshToken(refreshToken)
             .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+    }
+
+    private String getRefreshToken(String authorization) {
+        return authorization.split(" ")[1];
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
@@ -20,12 +20,10 @@ public class MemberInfoService {
 
     private final MemberService memberService;
 
-
     public MemberInfoResponseDto getMemberInfo(String authorization) {
         String refreshToken = authorization.split(" ")[1];
 
-        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
-            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+        Member findMember = getMemberByRefreshToken(refreshToken);
 
         return MemberInfoResponseDto.of(findMember);
     }
@@ -34,8 +32,7 @@ public class MemberInfoService {
     public MemberInfoResponseDto updateUsername(String authorization, UpdateUsernameRequestDto requestDto) {
         String refreshToken = authorization.split(" ")[1];
 
-        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
-            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+        Member findMember = getMemberByRefreshToken(refreshToken);
 
         String newUsername = requestDto.getUsername();
         findMember.updateUsername(newUsername);
@@ -47,11 +44,15 @@ public class MemberInfoService {
     public String memberSecession(String authorization) {
         String refreshToken = authorization.split(" ")[1];
 
-        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
-            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+        Member findMember = getMemberByRefreshToken(refreshToken);
 
         memberService.delete(findMember);
         return "secession : success";
+    }
+
+    private Member getMemberByRefreshToken(String refreshToken) {
+        return memberService.findMemberByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
@@ -1,0 +1,26 @@
+package com.dailymap.dailymap.api.memberinfo.service;
+
+import com.dailymap.dailymap.api.memberinfo.dto.MemberInfoResponseDto;
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.member.service.MemberService;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import com.dailymap.dailymap.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInfoService {
+
+    private final MemberService memberService;
+
+
+    public MemberInfoResponseDto getMemberInfo(String authorization) {
+        String refreshToken = authorization.split(" ")[1];
+
+        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+
+        return MemberInfoResponseDto.of(findMember);
+    }
+}

--- a/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memberinfo/service/MemberInfoService.java
@@ -42,4 +42,16 @@ public class MemberInfoService {
 
         return MemberInfoResponseDto.of(findMember);
     }
+
+    @Transactional
+    public String memberSecession(String authorization) {
+        String refreshToken = authorization.split(" ")[1];
+
+        Member findMember = memberService.findMemberByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN));
+
+        memberService.delete(findMember);
+        return "secession : success";
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/domain/member/service/MemberService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/service/MemberService.java
@@ -32,4 +32,10 @@ public class MemberService {
     public Optional<Member> findMemberByRefreshToken(String refreshToken) {
         return memberRepository.findByRefreshToken(refreshToken);
     }
+
+    @Transactional
+    public void delete(Member member) {
+        memberRepository.delete(member);
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/dailymap/dailymap/global/interceptor/AuthenticationInterceptor.java
@@ -33,12 +33,17 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             throw new AuthorizationException(NOT_EXISTS_AUTHORIZATION);
         }
 
-        String bearer = authorization.split(" ")[0];
+        String[] headerSplits = authorization.split(" ");
+        if (headerSplits.length != 2) {
+            throw new AuthorizationException(NOT_VALID_TOKEN);
+        }
+
+        String bearer = headerSplits[0];
         if (!"Bearer".equals(bearer)) {
             throw new AuthorizationException(NOT_VALID_BEARER_GRANT_TYPE);
         }
 
-        String token = authorization.split(" ")[1];
+        String token = headerSplits[1];
         if (!tokenManager.validateToken(token)) {
             throw new AuthorizationException(NOT_VALID_TOKEN);
         }


### PR DESCRIPTION
## 구현사항

설정 탭에서 표시할 사용자 정보를 조회하기 위한 API
사용자 정보 중 닉네임을 변경하기 위한 API
사용자 회원 탈퇴를 하기 위한 API

### 세부사항

- [GET]/api/auth/user 사용자 정보 조회
- [PATCH] /api/auth/user 사용자 닉네임 변경
- [DELETE] /api/auth/user 사용자 회원 탈퇴

- 헤더 정보에 Bearer [Refresh Token]
- 회원의 id, email, username(nickname)을 반환한다.
- 회원 탈퇴의 경우 "secession : success"를 반환한다.
- 리프레시 토큰이 만료되거나 잘못된 토큰을 보낼경우 Exception을 발생시킨다.