### PR TITLE
추억(게시물) 관련 API 구현

### DIFF
--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -16,11 +16,11 @@ public class MemoryController {
     private final MemoryApiService memoryService;
 
     @PostMapping
-    public ResponseEntity<MemoryResponseDto> savedMemory(
+    public ResponseEntity<MemoryResponseDto.Register> savedMemory(
         @RequestHeader("Authorization")String authorization,
-        @RequestBody MemoryRequestDto requestDto
+        @RequestBody MemoryRequestDto.Register requestDto
     ) {
-        MemoryResponseDto responseDto = memoryService.save(authorization, requestDto);
+        MemoryResponseDto.Register responseDto = memoryService.save(authorization, requestDto);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -6,8 +6,13 @@ import com.dailymap.dailymap.api.memory.service.MemoryApiService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +28,15 @@ public class MemoryController {
     ) {
         MemoryResponseDto.Register responseDto = memoryService.save(authorization, requestDto);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MemoryResponseDto.Find>> findAllMemory(
+        @RequestHeader("Authorization") String authorization,
+        @PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        List<MemoryResponseDto.Find> responseDtos = memoryService.getResponseDtos(authorization, pageable);
+        return ResponseEntity.ok(responseDtos);
     }
 
     @PatchMapping("{id}")

--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -31,10 +31,7 @@ public class MemoryController {
     }
 
     @GetMapping("{id}")
-    public ResponseEntity<MemoryResponseDto.Find> findMemory(
-        @RequestHeader("Authorization") String authorization,
-        @PathVariable Long id
-    ) {
+    public ResponseEntity<MemoryResponseDto.Find> findMemory(@PathVariable Long id) {
         MemoryResponseDto.Find responseDto = memoryService.getResponseDto(id);
         return ResponseEntity.ok(responseDto);
     }
@@ -54,13 +51,16 @@ public class MemoryController {
         @PathVariable final Long id,
         @RequestBody MemoryRequestDto.Update requestDto
     ) {
-        MemoryResponseDto.Update responseDto = memoryService.update(id, requestDto);
+        MemoryResponseDto.Update responseDto = memoryService.update(authorization, id, requestDto);
         return ResponseEntity.ok(responseDto);
     }
 
     @DeleteMapping("{id}")
-    public ResponseEntity<String> deleteMemory(@PathVariable final Long id) {
-        return ResponseEntity.ok(memoryService.delete(id));
+    public ResponseEntity<String> deleteMemory(
+        @RequestHeader("Authorization") String authorization,
+        @PathVariable final Long id
+    ) {
+        return ResponseEntity.ok(memoryService.delete(authorization,id));
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -1,0 +1,27 @@
+package com.dailymap.dailymap.api.memory.controller;
+
+import com.dailymap.dailymap.api.memory.dto.MemoryRequestDto;
+import com.dailymap.dailymap.api.memory.dto.MemoryResponseDto;
+
+import com.dailymap.dailymap.api.memory.service.MemoryApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/memory")
+public class MemoryController {
+
+    private final MemoryApiService memoryService;
+
+    @PostMapping
+    public ResponseEntity<MemoryResponseDto> savedMemory(
+        @RequestHeader("Authorization")String authorization,
+        @RequestBody MemoryRequestDto requestDto
+    ) {
+        MemoryResponseDto responseDto = memoryService.save(authorization, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -2,9 +2,10 @@ package com.dailymap.dailymap.api.memory.controller;
 
 import com.dailymap.dailymap.api.memory.dto.MemoryRequestDto;
 import com.dailymap.dailymap.api.memory.dto.MemoryResponseDto;
-
 import com.dailymap.dailymap.api.memory.service.MemoryApiService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,6 +33,11 @@ public class MemoryController {
     ) {
         MemoryResponseDto.Update responseDto = memoryService.getResponseDto(id, requestDto);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @DeleteMapping("{id}")
+    public ResponseEntity<String> deleteMemory(@PathVariable final Long id) {
+        return ResponseEntity.ok(memoryService.delete(id));
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -30,6 +30,15 @@ public class MemoryController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @GetMapping("{id}")
+    public ResponseEntity<MemoryResponseDto.Find> findMemory(
+        @RequestHeader("Authorization") String authorization,
+        @PathVariable Long id
+    ) {
+        MemoryResponseDto.Find responseDto = memoryService.getResponseDto(id);
+        return ResponseEntity.ok(responseDto);
+    }
+
     @GetMapping
     public ResponseEntity<List<MemoryResponseDto.Find>> findAllMemory(
         @RequestHeader("Authorization") String authorization,
@@ -45,7 +54,7 @@ public class MemoryController {
         @PathVariable final Long id,
         @RequestBody MemoryRequestDto.Update requestDto
     ) {
-        MemoryResponseDto.Update responseDto = memoryService.getResponseDto(id, requestDto);
+        MemoryResponseDto.Update responseDto = memoryService.update(id, requestDto);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/controller/MemoryController.java
@@ -24,4 +24,14 @@ public class MemoryController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @PatchMapping("{id}")
+    public ResponseEntity<MemoryResponseDto.Update> changeContent(
+        @RequestHeader("Authorization") String authorization,
+        @PathVariable final Long id,
+        @RequestBody MemoryRequestDto.Update requestDto
+    ) {
+        MemoryResponseDto.Update responseDto = memoryService.getResponseDto(id, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
@@ -30,4 +30,10 @@ public interface MemoryRequestDto {
         }
     }
 
+    @Builder
+    @Getter
+    class Update {
+        private String content;
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
@@ -4,8 +4,10 @@ import com.dailymap.dailymap.domain.member.model.Member;
 import com.dailymap.dailymap.domain.memory.model.Location;
 import com.dailymap.dailymap.domain.memory.model.Memory;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -30,8 +32,10 @@ public interface MemoryRequestDto {
         }
     }
 
-    @Builder
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     class Update {
         private String content;
     }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
@@ -1,0 +1,31 @@
+package com.dailymap.dailymap.api.memory.dto;
+
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.memory.model.Location;
+import com.dailymap.dailymap.domain.memory.model.Memory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MemoryRequestDto {
+
+    private List<String> imageUrls;
+
+    private String content;
+
+    private Location location;
+
+    public Memory toEntity(Member member) {
+        return Memory.builder()
+            .content(content)
+            .imageUrls(imageUrls)
+            .location(location)
+            .member(member)
+            .build();
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
@@ -9,23 +9,25 @@ import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-@Builder
-public class MemoryRequestDto {
+public interface MemoryRequestDto {
 
-    private List<String> imageUrls;
+    @Getter
+    @Builder
+    class Register {
+        private List<String> imageUrls;
 
-    private String content;
+        private String content;
 
-    private Location location;
+        private Location location;
 
-    public Memory toEntity(Member member) {
-        return Memory.builder()
-            .content(content)
-            .imageUrls(imageUrls)
-            .location(location)
-            .member(member)
-            .build();
+        public Memory toEntity(Member member) {
+            return Memory.builder()
+                .content(content)
+                .imageUrls(imageUrls)
+                .location(location)
+                .member(member)
+                .build();
+        }
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryRequestDto.java
@@ -22,11 +22,14 @@ public interface MemoryRequestDto {
 
         private Location location;
 
+        private String address;
+
         public Memory toEntity(Member member) {
             return Memory.builder()
                 .content(content)
                 .imageUrls(imageUrls)
                 .location(location)
+                .address(address)
                 .member(member)
                 .build();
         }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
@@ -51,4 +51,28 @@ public interface MemoryResponseDto {
         }
     }
 
+    @Builder
+    @Getter
+    class Find {
+        private Long id;
+
+        private List<String> imageUrls;
+
+        private String content;
+
+        private Location location;
+
+        private String createdDate;
+
+        public static MemoryResponseDto.Find from(Memory memory) {
+            return MemoryResponseDto.Find.builder()
+                .id(memory.getId())
+                .imageUrls(memory.getImageUrls())
+                .content(memory.getContent())
+                .location(memory.getLocation())
+                .createdDate(DateTimeUtils.convertToStringDateFormat(memory.getCreateTime()))
+                .build();
+        }
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
@@ -22,14 +22,17 @@ public interface MemoryResponseDto {
 
         private Location location;
 
+        private String address;
+
         private String createdDate;
 
         public static MemoryResponseDto.Register from(Memory memory) {
-            return MemoryResponseDto.Register.builder()
+            return Register.builder()
                 .id(memory.getId())
                 .imageUrls(memory.getImageUrls())
                 .content(memory.getContent())
                 .location(memory.getLocation())
+                .address(memory.getAddress())
                 .createdDate(DateTimeUtils.convertToStringDateFormat(memory.getCreateTime()))
                 .build();
         }
@@ -62,14 +65,17 @@ public interface MemoryResponseDto {
 
         private Location location;
 
+        private String address;
+
         private String createdDate;
 
         public static MemoryResponseDto.Find from(Memory memory) {
-            return MemoryResponseDto.Find.builder()
+            return Find.builder()
                 .id(memory.getId())
                 .imageUrls(memory.getImageUrls())
                 .content(memory.getContent())
                 .location(memory.getLocation())
+                .address(memory.getAddress())
                 .createdDate(DateTimeUtils.convertToStringDateFormat(memory.getCreateTime()))
                 .build();
         }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
@@ -9,28 +9,32 @@ import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-@Builder
-public class MemoryResponseDto {
+public interface MemoryResponseDto {
 
-    private Long id;
+    @Getter
+    @Builder
+    class Register {
+        private Long id;
 
-    private List<String> imageUrls;
+        private List<String> imageUrls;
 
-    private String content;
+        private String content;
 
-    private Location location;
+        private Location location;
 
-    private String createdDate;
+        private String createdDate;
 
-    public static MemoryResponseDto from(Memory memory) {
-        return MemoryResponseDto.builder()
-            .id(memory.getId())
-            .imageUrls(memory.getImageUrls())
-            .content(memory.getContent())
-            .location(memory.getLocation())
-            .createdDate(DateTimeUtils.convertToStringDateFormat(memory.getCreateTime()))
-            .build();
+        public static MemoryResponseDto.Register from(Memory memory) {
+            return MemoryResponseDto.Register.builder()
+                .id(memory.getId())
+                .imageUrls(memory.getImageUrls())
+                .content(memory.getContent())
+                .location(memory.getLocation())
+                .createdDate(DateTimeUtils.convertToStringDateFormat(memory.getCreateTime()))
+                .build();
+        }
     }
+
+
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
@@ -1,0 +1,36 @@
+package com.dailymap.dailymap.api.memory.dto;
+
+import com.dailymap.dailymap.domain.memory.model.Location;
+import com.dailymap.dailymap.domain.memory.model.Memory;
+import com.dailymap.dailymap.global.util.DateTimeUtils;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MemoryResponseDto {
+
+    private Long id;
+
+    private List<String> imageUrls;
+
+    private String content;
+
+    private Location location;
+
+    private String createdDate;
+
+    public static MemoryResponseDto from(Memory memory) {
+        return MemoryResponseDto.builder()
+            .id(memory.getId())
+            .imageUrls(memory.getImageUrls())
+            .content(memory.getContent())
+            .location(memory.getLocation())
+            .createdDate(DateTimeUtils.convertToStringDateFormat(memory.getCreateTime()))
+            .build();
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/dto/MemoryResponseDto.java
@@ -35,6 +35,20 @@ public interface MemoryResponseDto {
         }
     }
 
+    @Builder
+    @Getter
+    class Update {
+        private Long id;
 
+        private String content;
+
+        public static MemoryResponseDto.Update from(Memory memory) {
+            return Update
+                .builder()
+                .id(memory.getId())
+                .content(memory.getContent())
+                .build();
+        }
+    }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -11,8 +11,12 @@ import com.dailymap.dailymap.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMBER_NOY_EXISTS_BY_ACCESS_TOKEN;
 
@@ -36,6 +40,17 @@ public class MemoryApiService {
         Memory savedMemory = memoryService.save(memory);
 
         return MemoryResponseDto.Register.from(savedMemory);
+    }
+
+    public List<MemoryResponseDto.Find> getResponseDtos(final String authorization, final Pageable pageable) {
+        String email = getMemberEmail(authorization);
+        Member findMember = getMemberByEmail(email);
+
+        List<Memory> memories = memoryService.findAllByMember(findMember, pageable);
+
+        return memories.stream()
+            .map(MemoryResponseDto.Find::from)
+            .collect(Collectors.toList());
     }
 
     private Member getMemberByEmail(final String email) {
@@ -66,4 +81,5 @@ public class MemoryApiService {
 
         return "success";
     }
+
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -32,6 +32,8 @@ public class MemoryApiService {
 
     private final MemoryService memoryService;
 
+    private final String DELETE_SUCCESS_MESSAGE = "success";
+
     @Transactional
     public MemoryResponseDto.Register save(final String authorization, final MemoryRequestDto.Register requestDto) {
         String email = getMemberEmail(authorization);
@@ -52,6 +54,7 @@ public class MemoryApiService {
         String email = getMemberEmail(authorization);
         Member findMember = getMemberByEmail(email);
 
+        // todo : QueryDSL 사용하여 페이징 반영한 DTO List 반환되도록 리팩터링 시도하기
         List<Memory> memories = memoryService.findAllByMember(findMember, pageable);
 
         return memories.stream()
@@ -90,14 +93,14 @@ public class MemoryApiService {
         validateMemory(authorization, findMemory);
 
         memoryService.delete(findMemory);
-        return "success";
+        return DELETE_SUCCESS_MESSAGE;
     }
 
     private void validateMemory(String authorization, Memory memory) {
         String email = getMemberEmail(authorization);
         Member findMember = memory.getMember();
 
-        if (!email.equals(findMember.getEmail())) {
+        if (!findMember.isSameEmail(email)) {
             throw new BusinessException(NOT_VALID_MEMORY_BY_MEMBER);
         }
     }

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -42,6 +42,11 @@ public class MemoryApiService {
         return MemoryResponseDto.Register.from(savedMemory);
     }
 
+    public MemoryResponseDto.Find getResponseDto(final Long id) {
+        Memory memory = memoryService.findById(id);
+        return MemoryResponseDto.Find.from(memory);
+    }
+
     public List<MemoryResponseDto.Find> getResponseDtos(final String authorization, final Pageable pageable) {
         String email = getMemberEmail(authorization);
         Member findMember = getMemberByEmail(email);
@@ -65,7 +70,7 @@ public class MemoryApiService {
     }
 
     @Transactional
-    public MemoryResponseDto.Update getResponseDto(final Long id, final MemoryRequestDto.Update requestDto) {
+    public MemoryResponseDto.Update update(final Long id, final MemoryRequestDto.Update requestDto) {
         String newContent = requestDto.getContent();
 
         Memory findMemory = memoryService.findById(id);

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -28,14 +28,14 @@ public class MemoryApiService {
     private final MemoryRepository memoryRepository;
 
     @Transactional
-    public MemoryResponseDto save(final String authorization, final MemoryRequestDto requestDto) {
+    public MemoryResponseDto.Register save(final String authorization, final MemoryRequestDto.Register requestDto) {
         String email = getMemberEmail(authorization);
         Member findMember = getMemberByEmail(email);
 
         Memory memory = requestDto.toEntity(findMember);
         Memory savedMemory = memoryRepository.save(memory);
 
-        return MemoryResponseDto.from(savedMemory);
+        return MemoryResponseDto.Register.from(savedMemory);
     }
 
     private Member getMemberByEmail(final String email) {

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -1,0 +1,52 @@
+package com.dailymap.dailymap.api.memory.service;
+
+import com.dailymap.dailymap.api.memory.dto.MemoryRequestDto;
+import com.dailymap.dailymap.api.memory.dto.MemoryResponseDto;
+import com.dailymap.dailymap.domain.jwt.service.TokenManager;
+import com.dailymap.dailymap.domain.member.model.Member;
+import com.dailymap.dailymap.domain.member.service.MemberService;
+import com.dailymap.dailymap.domain.memory.model.Memory;
+import com.dailymap.dailymap.domain.memory.repository.MemoryRepository;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMBER_NOY_EXISTS_BY_ACCESS_TOKEN;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemoryApiService {
+
+    private final MemberService memberService;
+
+    private final TokenManager tokenManager;
+
+    private final MemoryRepository memoryRepository;
+
+    @Transactional
+    public MemoryResponseDto save(final String authorization, final MemoryRequestDto requestDto) {
+        String email = getMemberEmail(authorization);
+        Member findMember = getMemberByEmail(email);
+
+        Memory memory = requestDto.toEntity(findMember);
+        Memory savedMemory = memoryRepository.save(memory);
+
+        return MemoryResponseDto.from(savedMemory);
+    }
+
+    private Member getMemberByEmail(final String email) {
+        return memberService.findMemberByEmail(email)
+            .orElseThrow(() -> new BusinessException(MEMBER_NOY_EXISTS_BY_ACCESS_TOKEN));
+    }
+
+    private String getMemberEmail(final String authorization) {
+        String accessToken = authorization.split(" ")[1];
+
+        return tokenManager.getMemberEmail(accessToken);
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -6,7 +6,7 @@ import com.dailymap.dailymap.domain.jwt.service.TokenManager;
 import com.dailymap.dailymap.domain.member.model.Member;
 import com.dailymap.dailymap.domain.member.service.MemberService;
 import com.dailymap.dailymap.domain.memory.model.Memory;
-import com.dailymap.dailymap.domain.memory.repository.MemoryRepository;
+import com.dailymap.dailymap.domain.memory.service.MemoryService;
 import com.dailymap.dailymap.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class MemoryApiService {
 
     private final TokenManager tokenManager;
 
-    private final MemoryRepository memoryRepository;
+    private final MemoryService memoryService;
 
     @Transactional
     public MemoryResponseDto.Register save(final String authorization, final MemoryRequestDto.Register requestDto) {
@@ -33,7 +33,7 @@ public class MemoryApiService {
         Member findMember = getMemberByEmail(email);
 
         Memory memory = requestDto.toEntity(findMember);
-        Memory savedMemory = memoryRepository.save(memory);
+        Memory savedMemory = memoryService.save(memory);
 
         return MemoryResponseDto.Register.from(savedMemory);
     }
@@ -47,6 +47,16 @@ public class MemoryApiService {
         String accessToken = authorization.split(" ")[1];
 
         return tokenManager.getMemberEmail(accessToken);
+    }
+
+    @Transactional
+    public MemoryResponseDto.Update getResponseDto(final Long id, final MemoryRequestDto.Update requestDto) {
+        String newContent = requestDto.getContent();
+
+        Memory findMemory = memoryService.findById(id);
+        findMemory.updateContent(newContent);
+
+        return MemoryResponseDto.Update.from(findMemory);
     }
 
 }

--- a/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
+++ b/src/main/java/com/dailymap/dailymap/api/memory/service/MemoryApiService.java
@@ -59,4 +59,11 @@ public class MemoryApiService {
         return MemoryResponseDto.Update.from(findMemory);
     }
 
+    @Transactional
+    public String delete(final Long id) {
+        Memory findMemory = memoryService.findById(id);
+        memoryService.delete(findMemory);
+
+        return "success";
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
@@ -2,6 +2,7 @@ package com.dailymap.dailymap.domain.member.model;
 
 import com.dailymap.dailymap.domain.common.BaseEntity;
 import com.dailymap.dailymap.domain.member.constant.MemberType;
+import com.dailymap.dailymap.domain.memory.model.Memory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,6 +35,9 @@ public class Member extends BaseEntity {
 
     @Column(length = 250)
     private LocalDateTime tokenExpirationTime;
+
+    @OneToMany(mappedBy = "member")
+    private List<Memory> memories;
 
     public static Member of(String email, String name, MemberType memberType) {
         return Member.builder()

--- a/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
+++ b/src/main/java/com/dailymap/dailymap/domain/member/model/Member.java
@@ -59,4 +59,8 @@ public class Member extends BaseEntity {
     public void expireRefreshToken() {
         this.tokenExpirationTime = LocalDateTime.now();
     }
+
+    public boolean isSameEmail(String authEmail) {
+        return email.equals(authEmail);
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Location.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Location.java
@@ -1,10 +1,14 @@
 package com.dailymap.dailymap.domain.memory.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Location {
 
     private double latitude;

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Location.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Location.java
@@ -1,0 +1,14 @@
+package com.dailymap.dailymap.domain.memory.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Location {
+
+    private double latitude;
+
+    private double longitude;
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Location.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Location.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class Location {
 
-    private double latitude;
+    private Double latitude;
 
-    private double longitude;
+    private Double longitude;
 
 }

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
@@ -33,4 +33,8 @@ public class Memory extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
 }

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
@@ -29,6 +29,8 @@ public class Memory extends BaseEntity {
     @Embedded
     private Location location = new Location();
 
+    private String address;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
@@ -1,0 +1,35 @@
+package com.dailymap.dailymap.domain.memory.model;
+
+import com.dailymap.dailymap.domain.common.BaseEntity;
+import com.dailymap.dailymap.domain.member.model.Member;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Memory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection
+    @NonNull
+    private List<String> imageUrls;
+
+    @Column(length = 1000)
+    private String content;
+
+    @Embedded
+    private Location location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/model/Memory.java
@@ -2,9 +2,11 @@ package com.dailymap.dailymap.domain.memory.model;
 
 import com.dailymap.dailymap.domain.common.BaseEntity;
 import com.dailymap.dailymap.domain.member.model.Member;
+
 import lombok.*;
 
 import javax.persistence.*;
+
 import java.util.List;
 
 @Entity
@@ -19,14 +21,13 @@ public class Memory extends BaseEntity {
     private Long id;
 
     @ElementCollection
-    @NonNull
     private List<String> imageUrls;
 
     @Column(length = 1000)
     private String content;
 
     @Embedded
-    private Location location;
+    private Location location = new Location();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/dailymap/dailymap/domain/memory/repository/MemoryRepository.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/repository/MemoryRepository.java
@@ -1,0 +1,7 @@
+package com.dailymap.dailymap.domain.memory.repository;
+
+import com.dailymap.dailymap.domain.memory.model.Memory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoryRepository extends JpaRepository<Memory, Long> {
+}

--- a/src/main/java/com/dailymap/dailymap/domain/memory/repository/MemoryRepository.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/repository/MemoryRepository.java
@@ -1,7 +1,13 @@
 package com.dailymap.dailymap.domain.memory.repository;
 
+import com.dailymap.dailymap.domain.member.model.Member;
 import com.dailymap.dailymap.domain.memory.model.Memory;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
+    List<Memory> findAllByMember(final Member member, Pageable pageable);
 }

--- a/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
@@ -1,0 +1,28 @@
+package com.dailymap.dailymap.domain.memory.service;
+
+import com.dailymap.dailymap.domain.memory.model.Memory;
+import com.dailymap.dailymap.domain.memory.repository.MemoryRepository;
+import com.dailymap.dailymap.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMORY_NOT_EXISTS_BY_ID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemoryService {
+
+    private final MemoryRepository memoryRepository;
+
+    public Memory save(final Memory memory) {
+        return memoryRepository.save(memory);
+    }
+
+    public Memory findById(final Long id) {
+        return memoryRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(MEMORY_NOT_EXISTS_BY_ID));
+    }
+
+}

--- a/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
@@ -25,4 +25,8 @@ public class MemoryService {
             .orElseThrow(() -> new BusinessException(MEMORY_NOT_EXISTS_BY_ID));
     }
 
+    @Transactional
+    public void delete(final Memory memory) {
+        memoryRepository.delete(memory);
+    }
 }

--- a/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
@@ -20,6 +20,7 @@ public class MemoryService {
 
     private final MemoryRepository memoryRepository;
 
+    @Transactional
     public Memory save(final Memory memory) {
         return memoryRepository.save(memory);
     }

--- a/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
+++ b/src/main/java/com/dailymap/dailymap/domain/memory/service/MemoryService.java
@@ -1,11 +1,15 @@
 package com.dailymap.dailymap.domain.memory.service;
 
+import com.dailymap.dailymap.domain.member.model.Member;
 import com.dailymap.dailymap.domain.memory.model.Memory;
 import com.dailymap.dailymap.domain.memory.repository.MemoryRepository;
 import com.dailymap.dailymap.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.dailymap.dailymap.global.error.exception.ErrorCode.MEMORY_NOT_EXISTS_BY_ID;
 
@@ -18,6 +22,10 @@ public class MemoryService {
 
     public Memory save(final Memory memory) {
         return memoryRepository.save(memory);
+    }
+
+    public List<Memory> findAllByMember(Member member, Pageable pageable) {
+        return memoryRepository.findAllByMember(member, pageable);
     }
 
     public Memory findById(final Long id) {

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     MEMBER_NOT_EXISTS(400, "해당 회원은 존재하지 않습니다."),
     MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN(400, "해당 리프레시 토큰을 가진 회원은 존재하지 않습니다."),
     MEMBER_NOY_EXISTS_BY_ACCESS_TOKEN(400, "해당 액세스 토큰을 가진 회원은 존재하지 않습니다."),
+
+    // 추억
+    MEMORY_NOT_EXISTS_BY_ID(401, "해당 ID에 해당하는 추억이 존재하지 않습니다."),
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     // 회원
     MEMBER_NOT_EXISTS(400, "해당 회원은 존재하지 않습니다."),
     MEMBER_NOT_EXISTS_BY_REFRESH_TOKEN(400, "해당 리프레시 토큰을 가진 회원은 존재하지 않습니다."),
+    MEMBER_NOY_EXISTS_BY_ACCESS_TOKEN(400, "해당 액세스 토큰을 가진 회원은 존재하지 않습니다."),
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dailymap/dailymap/global/error/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
     // 추억
     MEMORY_NOT_EXISTS_BY_ID(401, "해당 ID에 해당하는 추억이 존재하지 않습니다."),
+    NOT_VALID_MEMORY_BY_MEMBER(401, "해당 추억과 사용자가 일치하지 않습니다."),
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/dailymap/dailymap/global/util/DateTimeUtils.java
+++ b/src/main/java/com/dailymap/dailymap/global/util/DateTimeUtils.java
@@ -1,5 +1,7 @@
 package com.dailymap.dailymap.global.util;
 
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -10,6 +12,12 @@ public class DateTimeUtils {
         return date.toInstant()
             .atZone(ZoneId.systemDefault())
             .toLocalDateTime();
+    }
+
+    public static String convertToStringDateFormat(LocalDateTime localDateTime) {
+        Date date = Timestamp.valueOf(localDateTime);
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        return simpleDateFormat.format(date);
     }
 
 }

--- a/src/test/java/com/dailymap/dailymap/domain/memory/MemoryRepositoryTests.java
+++ b/src/test/java/com/dailymap/dailymap/domain/memory/MemoryRepositoryTests.java
@@ -1,0 +1,50 @@
+package com.dailymap.dailymap.domain.memory;
+
+import com.dailymap.dailymap.domain.memory.model.Location;
+import com.dailymap.dailymap.domain.memory.model.Memory;
+import com.dailymap.dailymap.domain.memory.repository.MemoryRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@DataJpaTest
+public class MemoryRepositoryTests {
+
+    @Autowired
+    private MemoryRepository memoryRepository;
+
+    @Test
+    @DisplayName("추억 생성 성공 검증 테스트")
+    @Transactional
+    public void createMemorySuccessTest() {
+        // Arrange
+        Location location = Location.builder()
+            .latitude(111.333)
+            .longitude(222.333)
+            .build();
+
+        Memory memory = Memory.builder()
+            .content("테스트 문구 입니다.")
+            .imageUrls(List.of("url_01.jpg","url_02.jpg"))
+            .location(location)
+            .build();
+
+        // Act
+        Memory savedMemory = memoryRepository.save(memory);
+
+        // Assert
+        assertEquals(1L, savedMemory.getId());
+        assertEquals("테스트 문구 입니다.", savedMemory.getContent());
+    }
+
+    // ToDo : 조회, 수정, 삭제 테스트 코드 작성
+
+}


### PR DESCRIPTION
## 내용

DROP 서비스에서 게시물에 해당하는 추억에 대한 API를 구현한다.

#29 Memory Entity, Repository 구현
#28 추억 등록
#32 추억수정
#31 목록 조회
추억 삭제

### 세부 구현내역

- [x] [POST] /api/memory - 추억 등록 
- [x] [PATCH] /api/memory/{id} - 추억 수정
- [x] [GET] /api/memory - 추억 목록 조회
- [x] [DELETE] /api/memory/{id} - 추억 삭제
